### PR TITLE
Remove ellipsis from NZ Herald article page

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -141,9 +141,9 @@ if (matchDomain('elmercurio.com')) {
         const parDom = parHtml.querySelector('div');
         articleContent.insertBefore(parDom, hiddenPar);
       }
+      removeDOMElement(articleOffer);
       const firstSpan = document.querySelector('p > span');
       if (firstSpan) { firstSpan.removeAttribute('class'); }
-      removeDOMElement(articleOffer);
     }
   }
   const premiumToaster = document.querySelector('#premium-toaster');


### PR DESCRIPTION
Reordered code so that the ellipsis class is properly removed from the first span on the page.